### PR TITLE
Fix player side collisions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1178,6 +1178,42 @@
           }
         }
 
+        // Clamp against block sides after horizontal movement
+        for (const block of blocks) {
+          if (
+            player.y < block.y + block.height &&
+            player.y + player.height > block.y
+          ) {
+            if (
+              player.velocityX > 0 &&
+              player.x + player.width > block.x &&
+              player.x < block.x
+            ) {
+              player.x = block.x - player.width;
+              player.velocityX = 0;
+            } else if (
+              player.velocityX < 0 &&
+              player.x < block.x + block.width &&
+              player.x + player.width > block.x + block.width
+            ) {
+              player.x = block.x + block.width;
+              player.velocityX = 0;
+            }
+
+            // Optional: bump head on blocks above
+            if (
+              player.velocityY < 0 &&
+              player.x + player.width * 0.8 > block.x &&
+              player.x + player.width * 0.2 < block.x + block.width &&
+              player.y <= block.y + block.height &&
+              player.y > block.y
+            ) {
+              player.y = block.y + block.height;
+              player.velocityY = 0;
+            }
+          }
+        }
+
         // Enemy collisions - player jumps on enemies
         for (let i = enemies.length - 1; i >= 0; i--) {
           const enemy = enemies[i];


### PR DESCRIPTION
## Summary
- block the player from passing through the sides of blocks
- optionally stop upward movement if the player's head hits a block

## Testing
- `node - <<'NODE'
const fs=require('fs');
const data=fs.readFileSync('index.html','utf8');
const match=data.match(/<script>([\s\S]*)<\/script>/);
try{ new Function(match[1]); console.log('JS parse OK'); }catch(e){ console.error(e); }
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68576ec0fe988325a1e13b1735d69f34