### PR TITLE
Fix side collision clamping

### DIFF
--- a/index.html
+++ b/index.html
@@ -1140,8 +1140,9 @@
         const playerBottomRow = Math.floor((player.y + player.height) / blockSize);
         const checkRows = Math.min(2 + Math.floor(Math.abs(player.velocityY) / 10), 4); // Check more rows for fast-falling
 
-        // Check collision with blocks in multiple rows below the player
-        for (let rowOffset = 0; rowOffset <= checkRows; rowOffset++) {
+        // Check collision with blocks in multiple rows around the player.
+        // Start one row higher to avoid missing collisions at high fall speeds.
+        for (let rowOffset = -1; rowOffset <= checkRows; rowOffset++) {
           const blockRow = blockRows[playerBottomRow + rowOffset];
           if (!blockRow) continue;
 

--- a/index.html
+++ b/index.html
@@ -1098,7 +1098,33 @@
         }
       }
 
+      // Clamp against block sides after horizontal movement
+      function clampPlayerToBlockSides() {
+        for (const block of blocks) {
+          if (
+            player.y < block.y + block.height &&
+            player.y + player.height > block.y
+          ) {
+            if (
+              player.velocityX > 0 &&
+              player.x + player.width > block.x &&
+              player.x < block.x
+            ) {
+              player.x = block.x - player.width;
+            } else if (
+              player.velocityX < 0 &&
+              player.x < block.x + block.width &&
+              player.x + player.width > block.x + block.width
+            ) {
+              player.x = block.x + block.width;
+            }
+          }
+        }
+      }
+
       function checkPlayerCollisions() {
+        // Clamp against block sides before checking vertical collisions
+        clampPlayerToBlockSides();
         // Block collisions
         let isOnPlatform = false;
 


### PR DESCRIPTION
## Summary
- add `clampPlayerToBlockSides` helper
- run side clamp before checking vertical collisions

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_685774d061648325a91be1d9c0878af5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved player movement by preventing the player from passing through the sides of blocks during horizontal movement.
  - Enhanced collision detection to better handle fast vertical falls, resulting in smoother gameplay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->