### PR TITLE
Improve UFO durability

### DIFF
--- a/index.html
+++ b/index.html
@@ -1412,38 +1412,32 @@
             // Only count if player is falling down onto enemy
             player.velocityY > 0
           ) {
-            // Player jumped on enemy
+            // Player jumped on enemy - kill instantly
             hitSound();
-            enemy.health =
-              (enemy.health ?? (enemy.type === "ufo" ? 4 : 1)) - 1;
-            enemy.flashTimer = 10;
+            enemies.splice(i, 1);
+            score += enemyValue;
 
-            if (enemy.health <= 0) {
-              enemies.splice(i, 1);
-              score += enemyValue;
-
-              // Visual poof effect on enemy death
-              createPoof(
-                enemy.x + enemy.width / 2,
-                enemy.y + enemy.height / 2,
-              );
-
-              // Chance to drop a pickup
-              if (Math.random() < pickupDropChance) {
-                pickups.push({
-                  x: enemy.x + enemy.width / 2 - pickupSize / 2,
-                  y: enemy.y + enemy.height / 2 - pickupSize / 2,
-                  width: pickupSize,
-                  height: pickupSize,
-                  type: "point",
-                  frameIndex: 0, // Starting frame for animation
-                  frameCounter: Math.floor(Math.random() * coinFrameCount), // Random start point for animation
-                });
-              }
-            }
+            // Visual poof effect on enemy death
+            createPoof(
+              enemy.x + enemy.width / 2,
+              enemy.y + enemy.height / 2,
+            );
 
             // Bounce the player
             player.velocityY = jumpStrength / 1.5;
+
+            // Chance to drop a pickup
+            if (Math.random() < pickupDropChance) {
+              pickups.push({
+                x: enemy.x + enemy.width / 2 - pickupSize / 2,
+                y: enemy.y + enemy.height / 2 - pickupSize / 2,
+                width: pickupSize,
+                height: pickupSize,
+                type: "point",
+                frameIndex: 0, // Starting frame for animation
+                frameCounter: Math.floor(Math.random() * coinFrameCount), // Random start point for animation
+              });
+            }
           }
         }
 

--- a/index.html
+++ b/index.html
@@ -695,6 +695,13 @@
           }
         }
 
+        const health =
+          extra.health !== undefined
+            ? extra.health
+            : type === "ufo"
+            ? 4
+            : 1;
+
         enemies.push(
           Object.assign(
             {
@@ -703,6 +710,8 @@
               y: newY,
               width: enemySize,
               height: enemySize,
+              health,
+              flashTimer: 0,
             },
             extra
           )
@@ -1172,31 +1181,36 @@
             ) {
               // Enemy hit by bullet
               bullets.splice(i, 1);
-              enemies.splice(j, 1);
               hitSound();
-              window.FarcadeSDK.singlePlayer.actions.hapticFeedback();
-              score += enemyValue;
-              bulletHit = true;
+              enemy.health = (enemy.health || 1) - 1;
+              enemy.flashTimer = 10;
 
-              // Visual poof effect on enemy death
-              createPoof(
-                enemy.x + enemy.width / 2,
-                enemy.y + enemy.height / 2,
-              );
+              if (enemy.health <= 0) {
+                enemies.splice(j, 1);
+                window.FarcadeSDK.singlePlayer.actions.hapticFeedback();
+                score += enemyValue;
 
-              // Chance to drop a pickup
-              if (Math.random() < pickupDropChance) {
-                pickups.push({
-                  x: enemy.x + enemy.width / 2 - pickupSize / 2,
-                  y: enemy.y + enemy.height / 2 - pickupSize / 2,
-                  width: pickupSize,
-                  height: pickupSize,
-                  type: "point",
-                  frameIndex: 0, // Starting frame for animation
-                  frameCounter: Math.floor(Math.random() * coinFrameCount), // Random start point for animation
-                });
+                // Visual poof effect on enemy death
+                createPoof(
+                  enemy.x + enemy.width / 2,
+                  enemy.y + enemy.height / 2,
+                );
+
+                // Chance to drop a pickup
+                if (Math.random() < pickupDropChance) {
+                  pickups.push({
+                    x: enemy.x + enemy.width / 2 - pickupSize / 2,
+                    y: enemy.y + enemy.height / 2 - pickupSize / 2,
+                    width: pickupSize,
+                    height: pickupSize,
+                    type: "point",
+                    frameIndex: 0, // Starting frame for animation
+                    frameCounter: Math.floor(Math.random() * coinFrameCount), // Random start point for animation
+                  });
+                }
               }
 
+              bulletHit = true;
               break;
             }
           }
@@ -1398,31 +1412,36 @@
             player.velocityY > 0
           ) {
             // Player jumped on enemy
-            enemies.splice(i, 1);
             hitSound();
-            score += enemyValue;
+            enemy.health = (enemy.health || 1) - 1;
+            enemy.flashTimer = 10;
 
-            // Visual poof effect on enemy death
-            createPoof(
-              enemy.x + enemy.width / 2,
-              enemy.y + enemy.height / 2,
-            );
+            if (enemy.health <= 0) {
+              enemies.splice(i, 1);
+              score += enemyValue;
+
+              // Visual poof effect on enemy death
+              createPoof(
+                enemy.x + enemy.width / 2,
+                enemy.y + enemy.height / 2,
+              );
+
+              // Chance to drop a pickup
+              if (Math.random() < pickupDropChance) {
+                pickups.push({
+                  x: enemy.x + enemy.width / 2 - pickupSize / 2,
+                  y: enemy.y + enemy.height / 2 - pickupSize / 2,
+                  width: pickupSize,
+                  height: pickupSize,
+                  type: "point",
+                  frameIndex: 0, // Starting frame for animation
+                  frameCounter: Math.floor(Math.random() * coinFrameCount), // Random start point for animation
+                });
+              }
+            }
 
             // Bounce the player
             player.velocityY = jumpStrength / 1.5;
-
-            // Chance to drop a pickup
-            if (Math.random() < pickupDropChance) {
-              pickups.push({
-                x: enemy.x + enemy.width / 2 - pickupSize / 2,
-                y: enemy.y + enemy.height / 2 - pickupSize / 2,
-                width: pickupSize,
-                height: pickupSize,
-                type: "point",
-                frameIndex: 0, // Starting frame for animation
-                frameCounter: Math.floor(Math.random() * coinFrameCount), // Random start point for animation
-              });
-            }
           }
         }
 
@@ -1892,6 +1911,12 @@
               }
             }
 
+            if (enemy.flashTimer > 0) {
+              const halfSize = enemySize / 2;
+              ctx.fillStyle = "rgba(255,0,0,0.5)";
+              ctx.fillRect(-halfSize, -halfSize, enemySize, enemySize);
+            }
+
             ctx.restore();
           }
         }
@@ -1933,6 +1958,10 @@
 
         for (let i = enemies.length - 1; i >= 0; i--) {
           const enemy = enemies[i];
+
+          if (enemy.flashTimer > 0) {
+            enemy.flashTimer -= delta;
+          }
 
           // Only update enemies that are on screen or close to it
           const screenY = enemy.y - cameraY;

--- a/index.html
+++ b/index.html
@@ -1182,7 +1182,8 @@
               // Enemy hit by bullet
               bullets.splice(i, 1);
               hitSound();
-              enemy.health = (enemy.health || 1) - 1;
+              enemy.health =
+                (enemy.health ?? (enemy.type === "ufo" ? 4 : 1)) - 1;
               enemy.flashTimer = 10;
 
               if (enemy.health <= 0) {
@@ -1413,7 +1414,8 @@
           ) {
             // Player jumped on enemy
             hitSound();
-            enemy.health = (enemy.health || 1) - 1;
+            enemy.health =
+              (enemy.health ?? (enemy.type === "ufo" ? 4 : 1)) - 1;
             enemy.flashTimer = 10;
 
             if (enemy.health <= 0) {


### PR DESCRIPTION
## Summary
- make `spawnEnemy` give UFOs 4 HP
- track enemy health and flash timer
- reduce UFO health on bullet collision
- reduce UFO health when jumped on
- flash red when hurt and gradually fade

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e5afde4cc8325b02f5bebba600652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enemies now have a health system, requiring multiple hits to defeat certain types (e.g., UFOs).
  * Visual feedback added: enemies briefly flash red when taking damage.

* **Improvements**
  * Enemy removal, scoring, effects, and pickups now occur only when enemy health is depleted, enhancing gameplay depth for both bullet and jump interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->